### PR TITLE
Expose wrapped fields in Logger interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ type Logger interface {
 
 	// Return a logger with the specified key-value pairs set, to be  included in a subsequent normal logging call
 	WithFields(keyValues LogFields) Logger
+
+	// Return map fields associated with this logger, if any (i.e. if this logger was returned from WithField[s])
+	// If no fields are set, returns nil
+	Fields() Fields
 }
 ```
 

--- a/interface.go
+++ b/interface.go
@@ -75,6 +75,10 @@ type Logger interface {
 
 	// Return a logger with the specified key-value pairs set, to be  included in a subsequent normal logging call
 	WithFields(keyValues LogFields) Logger
+
+	// Return map fields associated with this logger, if any (i.e. if this logger was returned from WithField[s])
+	// If no fields are set, returns nil
+	Fields() Fields
 }
 
 // Logfields is an interface for dictionaries passed to Logger's WithFields logging method.

--- a/logrus_logger.go
+++ b/logrus_logger.go
@@ -53,6 +53,18 @@ func (l barkLogrusLogger) WithField(key string, value interface{}) Logger {
 	return newBarkLogrusLogger(l.logrusLoggerOrEntry.WithField(key, value))
 }
 
-func (l barkLogrusLogger) WithFields(keyValues LogFields) Logger {
-	return newBarkLogrusLogger(l.logrusLoggerOrEntry.WithFields(logrus.Fields(keyValues.Fields())))
+func (l barkLogrusLogger) WithFields(logFields LogFields) Logger {
+	if (logFields == nil) {
+		return l
+	}
+
+	return newBarkLogrusLogger(l.logrusLoggerOrEntry.WithFields(logrus.Fields(logFields.Fields())))
+}
+
+func (l barkLogrusLogger) Fields() Fields {
+	if entry, ok := l.logrusLoggerOrEntry.(*logrus.Entry); ok && entry.Data != nil {
+		return Fields(entry.Data)
+	}
+
+	return nil
 }

--- a/logrus_logger_test.go
+++ b/logrus_logger_test.go
@@ -144,6 +144,58 @@ func TestWithFields(t *testing.T) {
 	})
 }
 
+func TestGetFields(t *testing.T) {
+	var logger bark.Logger
+
+	// Plain logger
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	require.Equal(t, logger.Fields(), bark.Fields(nil))
+
+	// Add nil, don't crash
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithFields(nil)
+	require.Equal(t, logger.Fields(), bark.Fields(nil))
+
+	// One field added
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithField("foo", "bar")
+	require.Equal(t, logger.Fields(), bark.Fields{"foo": "bar"})
+
+	// Two fields added at once
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithFields(bark.Fields{"foo": "bar", "baz": "bump"})
+	require.Equal(t, logger.Fields(), bark.Fields{"foo": "bar", "baz": "bump"})
+
+	// One then one
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithField("foo", "bar")
+	logger = logger.WithField("baz", "bump")
+	require.Equal(t, logger.Fields(), bark.Fields{"foo": "bar", "baz": "bump"})
+
+	// Two then one
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithFields(bark.Fields{"foo": "bar", "baz": "bump"})
+	logger = logger.WithField("x", "y")
+	require.Equal(t, logger.Fields(), bark.Fields{"foo": "bar", "baz": "bump", "x": "y"})
+
+	// One then two
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithField("x", "y")
+	logger = logger.WithFields(bark.Fields{"foo": "bar", "baz": "bump"})
+	require.Equal(t, logger.Fields(), bark.Fields{"foo": "bar", "baz": "bump", "x": "y"})
+
+	// Two then two
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithFields(bark.Fields{"foo": "bar", "baz": "bump"})
+	logger = logger.WithFields(bark.Fields{"a": "b", "c": "d"})
+	require.Equal(t, logger.Fields(), bark.Fields{"foo": "bar", "baz": "bump", "a": "b", "c": "d"})
+
+	// Add empty map
+	logger = bark.NewLoggerFromLogrus(logrus.New())
+	logger = logger.WithFields(bark.Fields{})
+	require.Equal(t, logger.Fields(), bark.Fields{})
+}
+
 func doPanic(t *testing.T, panicker func(...interface{})) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Bark is essentially about a consistent interface to different
implementations, so returning the interface type (LogFields)
rather than the concrete type (Fields) seems to offer the most
flexibility.  It does have the visually strange effect that you get at the
underlying data by logger.Fields().Fields().
