### PR TITLE
Update import path for uber-common move

### DIFF
--- a/cactus_stats_reporter_test.go
+++ b/cactus_stats_reporter_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/bark"
-	"github.com/uber/bark/mocks"
+	"github.com/uber-common/bark"
+	"github.com/uber-common/bark/mocks"
 )
 
 func TestBarkCactusStatsReporter(t *testing.T) {

--- a/logrus_logger_test.go
+++ b/logrus_logger_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/bark"
+	"github.com/uber-common/bark"
 )
 
 // Create a logrus logger that writes its out output to a buffer for inspection

--- a/testhelp/fatal.go
+++ b/testhelp/fatal.go
@@ -23,7 +23,7 @@ import
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/uber/bark"
+	"github.com/uber-common/bark"
 )
 
 func main() {


### PR DESCRIPTION
This repository has found a new home, under uber-common.

/r @danielheller @jwolski 