### PR TITLE
Fix logrus import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Synopsis  [![Build Status](https://travis-ci.org/uber-common/bark.svg?branch=master)](https://travis-ci.org/uber-common/bark)
 
 Defines an interface for loggers and stats reporters that can be passed to Uber Go libraries.  
-Provides implementations which wrap a common logging module, [logrus](https://github.com/Sirupsen/logrus), 
+Provides implementations which wrap a common logging module, [logrus](https://github.com/sirupsen/logrus), 
 and a common stats reporting module [go-statsd-client](https://github.com/cactus/go-statsd-client).  
 Clients may also choose to implement these interfaces themselves.
 

--- a/interface.go
+++ b/interface.go
@@ -28,8 +28,8 @@ package bark
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/sirupsen/logrus"
 )
 
 // Logger is an interface for loggers accepted by Uber's libraries.

--- a/logrus_logger.go
+++ b/logrus_logger.go
@@ -18,7 +18,7 @@
 
 package bark
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // Interface provides indirection so Entry and Logger implementations can use exact same methods
 type logrusLoggerOrEntry interface {

--- a/logrus_logger_test.go
+++ b/logrus_logger_test.go
@@ -27,7 +27,7 @@ import (
 
 	"errors"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-common/bark"

--- a/testhelp/fatal.go
+++ b/testhelp/fatal.go
@@ -18,11 +18,10 @@
 
 package main
 
-import
-(
+import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/uber-common/bark"
 )
 


### PR DESCRIPTION
Magnus Sirupsen has changed his GitHub username, which breaks
everything - as the rest of the Go ecosystem updates to import
`github.com/sirupsen/logrus` instead of `github.com/Sirupsen/logrus`,
top-level projects will run into conflicts. Since we can't force Magnus
to change his username back, let's update to the correct path.

See https://github.com/sirupsen/logrus/pull/384 for details.