### PR TITLE
Captialize Sirupsen

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 // Logger is an interface for loggers accepted by Uber's libraries.


### PR DESCRIPTION
Everyone else imports this package as `github.com/Sirupsen/logrus` which creates problems.