### PR TITLE
Construct a bark logger from a zap logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: go
 sudo: false
 
 go:
-  - 1.6
   - 1.7
+  - 1.8
+  - 1.9
   - tip
 
 install:

--- a/interface.go
+++ b/interface.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cactus/go-statsd-client/statsd"
 	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Logger is an interface for loggers accepted by Uber's libraries.
@@ -104,6 +105,11 @@ func (f Fields) Fields() map[string]interface{} {
 // NewLoggerFromLogrus creates a bark-compliant wrapper for a logrus-brand logger.
 func NewLoggerFromLogrus(logger *logrus.Logger) Logger {
 	return newBarkLogrusLogger(logger)
+}
+
+// NewLoggerFromZap create a bark-compliant wrapper for a zap-brand logger.
+func NewLoggerFromZap(logger *zap.Logger) Logger {
+	return newBarkZapLogger(logger)
 }
 
 // Tags is an alias of map[string]string, a type for tags associated with a statistic

--- a/zap_logger.go
+++ b/zap_logger.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bark
+
+import (
+	"sort"
+
+	"go.uber.org/zap"
+)
+
+func newBarkZapLogger(l *zap.Logger) Logger {
+	return barkZapLogger{l.Sugar()}
+}
+
+type barkZapLogger struct{ *zap.SugaredLogger }
+
+func (l barkZapLogger) WithField(key string, value interface{}) Logger {
+	l.SugaredLogger = l.SugaredLogger.With(key, value) // safe to change because we pass-by-value
+	return l
+}
+
+func (l barkZapLogger) WithFields(keyValues LogFields) Logger {
+	barkFields := keyValues.Fields()
+
+	// Deterministic ordering of fields.
+	keys := make([]string, 0, len(barkFields))
+	for k := range barkFields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	zapFields := make([]interface{}, 0, len(barkFields))
+	for _, k := range keys {
+		zapFields = append(zapFields, zap.Any(k, barkFields[k]))
+	}
+
+	l.SugaredLogger = l.SugaredLogger.With(zapFields...) // safe to change because we pass-by-value
+	return l
+}
+
+func (l barkZapLogger) WithError(err error) Logger {
+	l.SugaredLogger = l.SugaredLogger.With(zap.Error(err)) // safe to change because we pass-by-value
+	return l
+}
+
+func (l barkZapLogger) Fields() Fields {
+	l.SugaredLogger.Warn("Fields() call to bark logger is not supported by Zap")
+	return nil
+}

--- a/zap_logger_test.go
+++ b/zap_logger_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bark_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/uber-common/bark"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func newTestLogger() (bark.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zap.LevelEnablerFunc(func(zapcore.Level) bool {
+		return true
+	}))
+	return bark.NewLoggerFromZap(zap.New(core)), logs
+}
+
+func TestBarkLoggerWith(t *testing.T) {
+	t.Run("WithField", func(t *testing.T) {
+		l, logs := newTestLogger()
+		l = l.WithField("foo", "bar")
+
+		l.Info("hello")
+		require.Equal(t, 1, logs.Len(), "message count did not match")
+
+		entry := logs.All()[0]
+		require.Len(t, entry.Context, 1, "context size did not match")
+		field := entry.Context[0]
+
+		assert.Equal(t, zapcore.StringType, field.Type, "field type did not match")
+		assert.Equal(t, "foo", field.Key, "field name did not match")
+		assert.Equal(t, "bar", field.String, "field value did not match")
+	})
+
+	t.Run("WithFields", func(t *testing.T) {
+		l, logs := newTestLogger()
+		l = l.WithFields(bark.Fields{
+			"foo": "bar",
+			"baz": int8(42),
+			"qux": errors.New("great sadness"),
+		})
+
+		l.Info("hello")
+		require.Equal(t, 1, logs.Len(), "message count did not match")
+
+		entry := logs.All()[0]
+		require.Len(t, entry.Context, 3, "context size did not match")
+
+		// We ensure deterministic ordering of fields by sorting them.
+		foo, baz, qux := entry.Context[1], entry.Context[0], entry.Context[2]
+
+		assert.Equal(t, "foo", foo.Key, "field name did not match")
+		assert.Equal(t, zapcore.StringType, foo.Type, "field type did not match")
+		assert.Equal(t, "bar", foo.String, "field value did not match")
+
+		assert.Equal(t, "baz", baz.Key, "field name did not match")
+		assert.Equal(t, zapcore.Int8Type, baz.Type, "field type did not match")
+		assert.EqualValues(t, 42, baz.Integer, "field value did not match")
+
+		assert.Equal(t, "qux", qux.Key, "field name did not match")
+		assert.Equal(t, zapcore.ErrorType, qux.Type, "field type did not match")
+		assert.Equal(t, errors.New("great sadness"), qux.Interface, "field value did not match")
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		l, logs := newTestLogger()
+		l = l.WithError(errors.New("great sadness"))
+
+		l.Info("hello")
+		require.Equal(t, 1, logs.Len(), "message count did not match")
+
+		entry := logs.All()[0]
+		require.Len(t, entry.Context, 1, "context size did not match")
+		field := entry.Context[0]
+
+		assert.Equal(t, zapcore.ErrorType, field.Type, "field type did not match")
+		assert.Equal(t, "error", field.Key, "field name did not match")
+		assert.Equal(t, errors.New("great sadness"), field.Interface, "field value did not match")
+	})
+
+	t.Run("Fields", func(t *testing.T) {
+		l, logs := newTestLogger()
+		l = l.WithField("foo", "bar").WithError(errors.New("great sadness"))
+		assert.Empty(t, l.Fields(), "expected empty field list")
+
+		require.Equal(t, 1, logs.Len(), "message count did not match")
+
+		entry := logs.All()[0]
+		assert.Equal(t,
+			"Fields() call to bark logger is not supported by Zap", entry.Message,
+			"message did not match")
+		assert.Equal(t, zapcore.WarnLevel, entry.Level, "message level did not match")
+	})
+}


### PR DESCRIPTION
NewLoggerFromZap converts a *zap.Logger to a bark.Logger