### PR TITLE
Introduce a bark-to-zap compatibility wrapper

### DIFF
--- a/zbark/barkify.go
+++ b/zbark/barkify.go
@@ -65,6 +65,9 @@ func (l barker) WithError(err error) bark.Logger {
 }
 
 func (l barker) Fields() bark.Fields {
-	l.SugaredLogger.Warn("Fields() call to bark logger is not supported by Zap")
+	// Zap has already marshaled the accumulated logger context to []byte, so we
+	// can't reconstruct the original objects. To satisfy this interface, just
+	// return nil.
+	l.SugaredLogger.Warn("zap-to-bark compatibility wrapper does not support Fields method")
 	return nil
 }

--- a/zbark/barkify_test.go
+++ b/zbark/barkify_test.go
@@ -32,16 +32,16 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func newTestLogger() (bark.Logger, *observer.ObservedLogs) {
+func newTestBarker() (bark.Logger, *observer.ObservedLogs) {
 	core, logs := observer.New(zap.LevelEnablerFunc(func(zapcore.Level) bool {
 		return true
 	}))
-	return zbark.New(zap.New(core)), logs
+	return zbark.Barkify(zap.New(core)), logs
 }
 
 func TestBarkLoggerWith(t *testing.T) {
 	t.Run("WithField", func(t *testing.T) {
-		l, logs := newTestLogger()
+		l, logs := newTestBarker()
 		l = l.WithField("foo", "bar")
 
 		l.Info("hello")
@@ -57,7 +57,7 @@ func TestBarkLoggerWith(t *testing.T) {
 	})
 
 	t.Run("WithFields", func(t *testing.T) {
-		l, logs := newTestLogger()
+		l, logs := newTestBarker()
 		l = l.WithFields(bark.Fields{
 			"foo": "bar",
 			"baz": int8(42),
@@ -87,7 +87,7 @@ func TestBarkLoggerWith(t *testing.T) {
 	})
 
 	t.Run("WithError", func(t *testing.T) {
-		l, logs := newTestLogger()
+		l, logs := newTestBarker()
 		l = l.WithError(errors.New("great sadness"))
 
 		l.Info("hello")
@@ -103,7 +103,7 @@ func TestBarkLoggerWith(t *testing.T) {
 	})
 
 	t.Run("Fields", func(t *testing.T) {
-		l, logs := newTestLogger()
+		l, logs := newTestBarker()
 		l = l.WithField("foo", "bar").WithError(errors.New("great sadness"))
 		assert.Empty(t, l.Fields(), "expected empty field list")
 

--- a/zbark/barkify_test.go
+++ b/zbark/barkify_test.go
@@ -111,7 +111,7 @@ func TestBarkLoggerWith(t *testing.T) {
 
 		entry := logs.All()[0]
 		assert.Equal(t,
-			"Fields() call to bark logger is not supported by Zap", entry.Message,
+			"zap-to-bark compatibility wrapper does not support Fields method", entry.Message,
 			"message did not match")
 		assert.Equal(t, zapcore.WarnLevel, entry.Level, "message level did not match")
 	})

--- a/zbark/zapify.go
+++ b/zbark/zapify.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zbark
+
+import (
+	"fmt"
+
+	"github.com/uber-common/bark"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Zapify wraps a bark logger in a compatibility layer to produce a
+// *zap.Logger. Note that the wrapper always treats zap's DPanicLevel as an
+// error (even in production).
+func Zapify(l bark.Logger) *zap.Logger {
+	return zap.New(&zapper{l})
+}
+
+type zapper struct {
+	l bark.Logger
+}
+
+func (z *zapper) Enabled(lvl zapcore.Level) bool {
+	return true
+}
+
+func (z *zapper) With(fs []zapcore.Field) zapcore.Core {
+	return &zapper{z.with(fs)}
+}
+
+func (z *zapper) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(ent, z)
+}
+
+func (z *zapper) Write(ent zapcore.Entry, fs []zapcore.Field) error {
+	logger := z.with(fs)
+
+	var logFunc func(string, ...interface{})
+	switch ent.Level {
+	case zapcore.DebugLevel:
+		logFunc = logger.Debugf
+	case zapcore.InfoLevel:
+		logFunc = logger.Infof
+	case zapcore.WarnLevel:
+		logFunc = logger.Warnf
+	case zapcore.ErrorLevel, zapcore.DPanicLevel:
+		logFunc = logger.Errorf
+	case zapcore.PanicLevel:
+		logFunc = logger.Panicf
+	case zapcore.FatalLevel:
+		logFunc = logger.Fatalf
+	default:
+		return fmt.Errorf("bark-to-zap compatibility wrapper got unknown level %v", ent.Level)
+	}
+	// The underlying bark logger timestamps the entry.
+	logFunc(ent.Message)
+	return nil
+}
+
+func (z *zapper) Sync() error {
+	return nil
+}
+
+func (z *zapper) with(fs []zapcore.Field) bark.Logger {
+	me := zapcore.NewMapObjectEncoder()
+	for _, f := range fs {
+		f.AddTo(me)
+	}
+	return z.l.WithFields(bark.Fields(me.Fields))
+}

--- a/zbark/zapify_test.go
+++ b/zbark/zapify_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zbark_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-common/bark"
+	"github.com/uber-common/bark/zbark"
+)
+
+func newTestZapper() (*zap.Logger, *bytes.Buffer) {
+	buf := bytes.NewBuffer(nil)
+	barkLogger := &logrus.Logger{
+		Out:   buf,
+		Hooks: make(logrus.LevelHooks),
+		Formatter: &logrus.JSONFormatter{
+			DisableTimestamp: true,
+		},
+		Level: logrus.DebugLevel,
+	}
+	return zbark.Zapify(bark.NewLoggerFromLogrus(barkLogger)), buf
+}
+
+func assertJSON(t testing.TB, expected map[string]interface{}, buf *bytes.Buffer) {
+	line := bytes.TrimSpace(buf.Bytes())
+	msg := make(map[string]interface{})
+	if err := json.Unmarshal(line, &msg); err != nil {
+		t.Fatalf("can't unmarshal JSON log: %s", string(line))
+	}
+	assert.Equal(t, expected, msg, "unexpected log message")
+}
+
+func TestZapLoggerWith(t *testing.T) {
+	log, buf := newTestZapper()
+	log.With(zap.String("foo", "bar")).Info("hello", zap.String("baz", "quux"))
+	assertJSON(t, map[string]interface{}{
+		"foo":   "bar",
+		"baz":   "quux",
+		"msg":   "hello",
+		"level": "info",
+	}, buf)
+}
+
+func TestZapLoggerLogging(t *testing.T) {
+	const msg = "hello"
+
+	log, buf := newTestZapper()
+	assertLogged := func(expected string) {
+		assertJSON(t, map[string]interface{}{
+			"msg":   msg,
+			"level": expected,
+		}, buf)
+	}
+
+	tests := []struct {
+		f     func(string, ...zapcore.Field)
+		level zapcore.Level
+		want  string
+	}{
+		{log.Debug, zapcore.DebugLevel, "debug"},
+		{log.Info, zapcore.InfoLevel, "info"},
+		{log.Warn, zapcore.WarnLevel, "warning"},
+		{log.Error, zapcore.ErrorLevel, "error"},
+		{log.DPanic, zapcore.DPanicLevel, "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			tt.f(msg)
+			assertLogged(tt.want)
+			buf.Reset()
+
+			if ce := log.Check(tt.level, msg); ce != nil {
+				ce.Write()
+			}
+			assertLogged(tt.want)
+			buf.Reset()
+		})
+	}
+}


### PR DESCRIPTION
This PR renames the zap-to-bark wrapper, then introduces a bark-to-zap wrapper.