### PR TITLE
Add constructor for a no-op logger

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -26,6 +26,7 @@
 package bark
 
 import (
+	"io/ioutil"
 	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
@@ -99,6 +100,15 @@ type Fields map[string]interface{}
 // Fields provides indirection for broader compatibility for the LogFields interface type.
 func (f Fields) Fields() map[string]interface{} {
 	return f
+}
+
+// NewNopLogger creates a no-op logger.
+func NewNopLogger() Logger {
+	return NewLoggerFromLogrus(&logrus.Logger{
+		Out:       ioutil.Discard,
+		Formatter: new(logrus.JSONFormatter),
+		Level:     logrus.DebugLevel,
+	})
 }
 
 // NewLoggerFromLogrus creates a bark-compliant wrapper for a logrus-brand logger.

--- a/logrus_logger_test.go
+++ b/logrus_logger_test.go
@@ -286,3 +286,10 @@ func TestFatalf(t *testing.T) {
 	barkStderr := execFatalTool(t, "bark.Fatalf")
 	validateOutput(t, barkStderr, logrusStderr)
 }
+
+func TestNopLogger(t *testing.T) {
+	assert.NotPanics(t, func() {
+		logger := bark.NewNopLogger()
+		logger.Info("hello")
+	})
+}


### PR DESCRIPTION
Users of this package often need a no-op logger for use in tests. Rather
than forcing them to look through the logrus documentation, provide a
simple no-op in bark.