### PR TITLE
Test on Go 1.10 and 1.9, drop 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - "1.9"
+  - "1.10"
   - tip
 
 install:


### PR DESCRIPTION
Update our Travis configuration to test on Go 1.9 and 1.10, dropping
1.8.