### PR TITLE
zbark: Ensure parity between Zap and Logrus output

### DIFF
--- a/zbark/barkify.go
+++ b/zbark/barkify.go
@@ -20,10 +20,12 @@ package zbark
 
 import (
 	"sort"
+	"time"
 
 	"github.com/uber-common/bark"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Barkify wraps a zap logger in a compatibility layer so that it satisfies
@@ -39,7 +41,7 @@ func Barkify(l *zap.Logger) bark.Logger {
 type barker struct{ *zap.SugaredLogger }
 
 func (l barker) WithField(key string, value interface{}) bark.Logger {
-	l.SugaredLogger = l.SugaredLogger.With(key, value) // safe to change because we pass-by-value
+	l.SugaredLogger = l.SugaredLogger.With(toZapField(key, value)) // safe to change because we pass-by-value
 	return l
 }
 
@@ -55,7 +57,7 @@ func (l barker) WithFields(keyValues bark.LogFields) bark.Logger {
 
 	zapFields := make([]interface{}, 0, len(barkFields))
 	for _, k := range keys {
-		zapFields = append(zapFields, zap.Any(k, barkFields[k]))
+		zapFields = append(zapFields, toZapField(k, barkFields[k]))
 	}
 
 	l.SugaredLogger = l.SugaredLogger.With(zapFields...) // safe to change because we pass-by-value
@@ -72,5 +74,159 @@ func (l barker) Fields() bark.Fields {
 	// can't reconstruct the original objects. To satisfy this interface, just
 	// return nil.
 	l.SugaredLogger.Warn("zap-to-bark compatibility wrapper does not support Fields method")
+	return nil
+}
+
+// toZapField converts a logrus field to a zap field.
+//
+// This relies on Zap's field constructors for fields when possible but falls
+// back to zap.Reflect for all other fields.
+//
+// In the interest of conforming to the output of logrus, this does not use
+// zap.Any. That's because logrus eventually uses encoding/json to encode
+// everything -- same as zap.Reflect.
+func toZapField(key string, v interface{}) zap.Field {
+	switch val := v.(type) {
+
+	// Types that implement ObjectMarshaler or ArrayMarshaler are
+	// explicitly specifying how they want to be logged with Zap. We don't
+	// care about parity with logrus in that case.
+	case zapcore.ObjectMarshaler:
+		return zap.Object(key, val)
+	case zapcore.ArrayMarshaler:
+		return zap.Array(key, val)
+
+	case bool:
+		return zap.Bool(key, val)
+	case *bool:
+		return zap.Boolp(key, val)
+	case []bool:
+		return zap.Bools(key, val)
+
+	case float32:
+		return zap.Float32(key, val)
+	case *float32:
+		return zap.Float32p(key, val)
+	case []float32:
+		return zap.Float32s(key, val)
+
+	case float64:
+		return zap.Float64(key, val)
+	case *float64:
+		return zap.Float64p(key, val)
+	case []float64:
+		return zap.Float64s(key, val)
+
+	case int:
+		return zap.Int(key, val)
+	case *int:
+		return zap.Intp(key, val)
+	case []int:
+		return zap.Ints(key, val)
+
+	case int8:
+		return zap.Int8(key, val)
+	case *int8:
+		return zap.Int8p(key, val)
+	case []int8:
+		return zap.Int8s(key, val)
+
+	case int16:
+		return zap.Int16(key, val)
+	case *int16:
+		return zap.Int16p(key, val)
+	case []int16:
+		return zap.Int16s(key, val)
+
+	case int32:
+		return zap.Int32(key, val)
+	case *int32:
+		return zap.Int32p(key, val)
+	case []int32:
+		return zap.Int32s(key, val)
+
+	case int64:
+		return zap.Int64(key, val)
+	case *int64:
+		return zap.Int64p(key, val)
+	case []int64:
+		return zap.Int64s(key, val)
+
+	case string:
+		return zap.String(key, val)
+	case *string:
+		return zap.Stringp(key, val)
+	case []string:
+		return zap.Strings(key, val)
+
+	case uint:
+		return zap.Uint(key, val)
+	case *uint:
+		return zap.Uintp(key, val)
+	case []uint:
+		return zap.Uints(key, val)
+
+	case uint8:
+		return zap.Uint8(key, val)
+	case *uint8:
+		return zap.Uint8p(key, val)
+	// []uint8 == []byte. See below.
+
+	case uint16:
+		return zap.Uint16(key, val)
+	case *uint16:
+		return zap.Uint16p(key, val)
+	case []uint16:
+		return zap.Uint16s(key, val)
+
+	case uint32:
+		return zap.Uint32(key, val)
+	case *uint32:
+		return zap.Uint32p(key, val)
+	case []uint32:
+		return zap.Uint32s(key, val)
+
+	case uint64:
+		return zap.Uint64(key, val)
+	case *uint64:
+		return zap.Uint64p(key, val)
+	case []uint64:
+		return zap.Uint64s(key, val)
+
+	case []byte:
+		return zap.Binary(key, val)
+
+	case time.Time:
+		return zap.Time(key, val)
+	case *time.Time:
+		return zap.Timep(key, val)
+	case []time.Time:
+		// return zap.Times(key, val)
+		// https://github.com/uber-go/zap/issues/798
+		// Fall back to zap.Reflect meanwhile.
+
+	// Logrus logs time.Duration as numbers so we should do the
+	// same.
+	case time.Duration:
+		return zap.Int64(key, int64(val))
+	case *time.Duration:
+		return zap.Int64p(key, (*int64)(val))
+	case []time.Duration:
+		return zap.Array(key, durationAsIntSlice(val))
+
+	case error:
+		return zap.NamedError(key, val)
+	}
+
+	// Use zap.Reflect for everything else.
+	return zap.Reflect(key, v)
+}
+
+type durationAsIntSlice []time.Duration
+
+func (ds durationAsIntSlice) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for _, d := range ds {
+		enc.AppendInt64(int64(d))
+	}
 	return nil
 }

--- a/zbark/barkify_test.go
+++ b/zbark/barkify_test.go
@@ -19,14 +19,17 @@
 package zbark_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
-	"github.com/uber-common/bark"
-	"github.com/uber-common/bark/zbark"
-
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-common/bark"
+	"github.com/uber-common/bark/zbark"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -115,4 +118,157 @@ func TestBarkLoggerWith(t *testing.T) {
 			"message did not match")
 		assert.Equal(t, zapcore.WarnLevel, entry.Level, "message level did not match")
 	})
+}
+
+func TestZapLogrusParity(t *testing.T) {
+	var (
+		boolv     bool          = true
+		float64v  float64       = 1.23
+		float32v  float32       = 4.5
+		intv      int           = 42
+		int8v     int8          = 6
+		int16v    int16         = 55
+		int32v    int32         = 200
+		int64v    int64         = 1234
+		stringv   string        = "hello world"
+		uintv     uint          = 128
+		uint8v    uint8         = 7
+		uint16v   uint16        = 56
+		uint32v   uint32        = 201
+		uint64v   uint64        = 1235
+		timev     time.Time     = time.Now()
+		durationv time.Duration = 42 * time.Minute
+	)
+
+	tests := []struct {
+		desc  string
+		field interface{}
+	}{
+		{desc: "nil", field: nil},
+		{desc: "bool", field: boolv},
+		{desc: "bool/ptr", field: &boolv},
+		{desc: "bool/slice", field: []bool{true, false, true}},
+		{desc: "float32", field: float32v},
+		{desc: "float32/ptr", field: &float32v},
+		{desc: "float32/slice", field: []float32{1.2, 2.3, 3.4}},
+		{desc: "float64", field: float64v},
+		{desc: "float64/ptr", field: &float64v},
+		{desc: "float64/slice", field: []float64{1.2, 2.3, 3.4}},
+		{desc: "int", field: intv},
+		{desc: "int/ptr", field: &intv},
+		{desc: "int/slice", field: []int{1, 2, 3}},
+		{desc: "int8", field: int8v},
+		{desc: "int8/ptr", field: &int8v},
+		{desc: "int8/slice", field: []int8{1, 2, 3}},
+		{desc: "int16", field: int16v},
+		{desc: "int16/ptr", field: &int16v},
+		{desc: "int16/slice", field: []int16{4, 5, 6}},
+		{desc: "int32", field: int32v},
+		{desc: "int32/ptr", field: &int32v},
+		{desc: "int32/slice", field: []int32{7, 8, 9}},
+		{desc: "int64", field: int64v},
+		{desc: "int64/ptr", field: &int64v},
+		{desc: "int64/slice", field: []int64{10, 11, 12}},
+		{desc: "string", field: stringv},
+		{desc: "string/ptr", field: &stringv},
+		{desc: "string/slice", field: []string{"a", "b", "c"}},
+		{desc: "uint", field: uintv},
+		{desc: "uint/ptr", field: &uintv},
+		{desc: "uint/slice", field: []uint{1, 2, 3}},
+		{desc: "uint8", field: uint8v},
+		{desc: "uint8/ptr", field: &uint8v},
+		{desc: "uint16", field: uint16v},
+		{desc: "uint16/ptr", field: &uint16v},
+		{desc: "uint16/slice", field: []uint16{4, 5, 6}},
+		{desc: "uint32", field: uint32v},
+		{desc: "uint32/ptr", field: &uint32v},
+		{desc: "uint32/slice", field: []uint32{7, 8, 9}},
+		{desc: "uint64", field: uint64v},
+		{desc: "uint64/ptr", field: &uint64v},
+		{desc: "uint64/slice", field: []uint64{10, 11, 12}},
+		{desc: "byte/slice", field: []byte{1, 2, 3}},
+		{desc: "time", field: timev},
+		{desc: "time/ptr", field: &timev},
+		{desc: "time/slice", field: []time.Time{timev, timev.Add(time.Second), timev.Add(time.Hour)}},
+		{desc: "duration", field: durationv},
+		{desc: "duration/ptr", field: &durationv},
+		{desc: "duration/slice", field: []time.Duration{time.Second, time.Minute, time.Hour}},
+		{desc: "error", field: errors.New("great sadness")},
+		{desc: "slice/any", field: []interface{}{"a", 1, true}},
+		{desc: "slice/empty", field: emptyZapArray{}},
+		{desc: "struct", field: struct{ SomeField string }{"foo"}},
+		{desc: "struct/empty", field: emptyZapStruct{}},
+		{desc: "struct/stringer", field: stringerStruct{SomeField: "foo"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			gotLogrus := logrusLog(t, tt.field)
+			t.Logf("logrus = %#v", gotLogrus)
+
+			gotZap := zapLog(t, tt.field)
+			t.Logf("zap = %#v", gotZap)
+
+			assert.Equal(t, gotLogrus, gotZap,
+				"output from logrus and zap does not match")
+		})
+	}
+}
+
+func logrusLog(t *testing.T, field interface{}) interface{} {
+	var buff bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&buff)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+
+	got, err := logAndParseField(field, &buff, bark.NewLoggerFromLogrus(logger))
+	require.NoError(t, err, "unable to parse logrus output: %s", buff.String())
+	return got
+}
+
+func zapLog(t *testing.T, field interface{}) interface{} {
+	encoderCfg := zap.NewDevelopmentEncoderConfig()
+	encoderCfg.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+
+	var buff bytes.Buffer
+	logger := zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderCfg),
+		zapcore.AddSync(&buff),
+		zapcore.InfoLevel,
+	))
+
+	got, err := logAndParseField(field, &buff, zbark.Barkify(logger))
+	require.NoError(t, err, "unable to parse Zap output: %s", buff.String())
+	return got
+}
+
+// Logs the provided field to the provided Bark logger and returns the
+// JSON object that results from that field.
+//
+// The logger must be configured to log JSON to the buffer.
+func logAndParseField(field interface{}, buff *bytes.Buffer, logger bark.Logger) (interface{}, error) {
+	logger.WithField("field", field).Info("msg")
+	var msg struct {
+		Field interface{} `json:"field"`
+	}
+	err := json.Unmarshal(buff.Bytes(), &msg)
+	return msg.Field, err
+}
+
+type stringerStruct struct{ SomeField string }
+
+func (s stringerStruct) String() string {
+	return "stringerStruct.String()"
+}
+
+type emptyZapStruct struct{}
+
+func (emptyZapStruct) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return nil
+}
+
+type emptyZapArray struct{}
+
+func (emptyZapStruct) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	return nil
 }


### PR DESCRIPTION
This changes how we convert `bark.Logger` fields into Zap fields to
ensure parity with Logrus' behavior to ease migration from Logrus to
Zap.

Previously, we relied on `zap.Any` to do the work here. This introduces
a problem because `zap.Any` supports more things than Logrus does, and
it handles structs that implement `fmt.Stringer` differently: namely, it
prioritizes `String()` over reflection.

Since Logrus' JSON encoder relies exclusively on `encoding/json` --
equivalent to `zap.Reflect`, this switches to using `zap.Reflect` for
fields.

However, for the sake of performance, this special cases conversion for
most types exposed by Zap so that we don't pay the heavy performance
penalty of `zap.Reflect` for primitive types.

Refs T5434921